### PR TITLE
Fix GitHub Actions workflow git config

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Setup git
         if: ${{ steps.version-check.outputs.skipped == 'false' }}
         run: |
-          git config --global user.email ${{ secrets.GH_EMAIL }}
-          git config --global user.name ${{ secrets.GH_USERNAME }}
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
       - name: Generate oclif README
         if: ${{ steps.version-check.outputs.skipped == 'false' }}
         id: oclif-readme


### PR DESCRIPTION
## Summary
- Fixed the failing GitHub Actions workflow by replacing secret-based git configuration with GitHub Actions bot credentials
- This resolves the "Setup git" step failure in the release workflow

## Test plan
- [ ] Verify the workflow runs successfully after merging
- [ ] Check that the git config step completes without errors
- [ ] Ensure subsequent steps can commit and push changes

🤖 Generated with [Claude Code](https://claude.ai/code)