### PR TITLE
Fix GitHub Actions push authentication

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -43,7 +43,7 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             git add .
             git commit -am "chore: update README.md"
-            git push -u origin ${{ github.ref_name }}
+            git push https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}.git HEAD:${{ github.ref_name }}
           fi
       - name: Create Github Release
         uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions workflow push authentication by using personal access token
- This resolves the permission denied errors when the workflow tries to push commits

## Test plan
- [ ] Verify the workflow can successfully push commits after merging
- [ ] Check that the oclif README generation step completes without errors
- [ ] Ensure the release workflow completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)