### PR TITLE
refactor: extract hook templates from init.ts to template files

### DIFF
--- a/templates/hooks/index.ts
+++ b/templates/hooks/index.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env bun
+
+import { runHook, log, type PreToolUsePayload, type PostToolUsePayload, type NotificationPayload, type StopPayload, type HookResponse, type BashToolInput } from './lib';
+import { saveSessionData } from './session';
+
+// PreToolUse handler - validate and potentially block dangerous commands
+async function preToolUse(payload: PreToolUsePayload): Promise<HookResponse> {
+  // Save session data
+  await saveSessionData('PreToolUse', payload);
+  
+  // Example: Block dangerous commands
+  if (payload.tool_name === 'Bash' && payload.tool_input && 'command' in payload.tool_input) {
+    const bashInput = payload.tool_input as BashToolInput;
+    const command = bashInput.command;
+    
+    // Block rm -rf commands
+    if (command && (command.includes('rm -rf /') || command.includes('rm -rf ~'))) {
+      return {
+        action: 'block',
+        stopReason: 'Dangerous command detected: rm -rf on system directories'
+      };
+    }
+  }
+  
+  // Allow all other commands
+  return { action: 'continue' };
+}
+
+// PostToolUse handler - log tool results
+async function postToolUse(payload: PostToolUsePayload): Promise<void> {
+  await saveSessionData('PostToolUse', payload);
+}
+
+// Notification handler - log notifications
+async function notification(payload: NotificationPayload): Promise<void> {
+  await saveSessionData('Notification', payload);
+}
+
+// Stop handler - log session end
+async function stop(payload: StopPayload): Promise<void> {
+  await saveSessionData('Stop', payload);
+}
+
+// Run the hook with our handlers
+runHook({
+  preToolUse,
+  postToolUse,
+  notification,
+  stop
+});

--- a/templates/hooks/session.ts
+++ b/templates/hooks/session.ts
@@ -1,0 +1,34 @@
+import { mkdir } from 'node:fs/promises';
+import { writeFile, readFile } from 'node:fs/promises';
+import * as path from 'path';
+import { tmpdir } from 'node:os';
+
+const SESSIONS_DIR = path.join(tmpdir(), 'claude-hooks-sessions');
+
+export async function saveSessionData(hookType: string, payload: any): Promise<void> {
+  try {
+    // Ensure sessions directory exists
+    await mkdir(SESSIONS_DIR, { recursive: true });
+    
+    const timestamp = new Date().toISOString();
+    const sessionFile = path.join(SESSIONS_DIR, `${payload.session_id}.json`);
+    
+    let sessionData: any[] = [];
+    try {
+      const existing = await readFile(sessionFile, 'utf-8');
+      sessionData = JSON.parse(existing);
+    } catch {
+      // File doesn't exist yet
+    }
+    
+    sessionData.push({
+      timestamp,
+      hookType,
+      payload
+    });
+    
+    await writeFile(sessionFile, JSON.stringify(sessionData, null, 2));
+  } catch (error) {
+    console.error('Failed to save session data:', error);
+  }
+}


### PR DESCRIPTION
## Summary
- Extracted hardcoded template strings from init.ts into actual template files
- Created templates/hooks/session.ts and templates/hooks/index.ts
- Updated init.ts to copy these templates instead of using inline strings

## Test plan
- [ ] CI tests pass
- [ ] `claude init` command still works correctly
- [ ] Generated hook files match expected output

🤖 Generated with [Claude Code](https://claude.ai/code)