### PR TITLE
Use built-in GITHUB_TOKEN with proper permissions

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -5,13 +5,14 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_TOKEN }}
       - uses: actions/setup-node@v4
       - name: Check if version already exists
         id: version-check


### PR DESCRIPTION
## Summary
- Use built-in GITHUB_TOKEN instead of custom GH_TOKEN secret
- Add contents: write permission to allow the workflow to push changes
- Simplifies authentication and follows GitHub Actions best practices

## Test plan
- [ ] Verify the workflow runs without authentication errors
- [ ] Check that the workflow can successfully push commits
- [ ] Ensure the release workflow completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)