### PR TITLE
Replace all GH_TOKEN references with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -31,7 +31,7 @@ jobs:
             echo "tag=v$package_version" >> $GITHUB_OUTPUT
           fi
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup git
         if: ${{ steps.version-check.outputs.skipped == 'false' }}
         run: |
@@ -55,5 +55,5 @@ jobs:
           name: ${{ steps.version-check.outputs.tag }}
           tag: ${{ steps.version-check.outputs.tag }}
           commit: ${{ github.ref_name }}
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           skipIfReleaseExists: true


### PR DESCRIPTION
## Summary
- Replace all instances of custom GH_TOKEN with built-in GITHUB_TOKEN
- This completes the migration to using GitHub's built-in authentication

## Test plan
- [ ] Verify the version check step works with GITHUB_TOKEN
- [ ] Confirm the release creation step succeeds
- [ ] Ensure the complete workflow runs without errors

🤖 Generated with [Claude Code](https://claude.ai/code)