### PR TITLE
fix: get hook_type from process.argv[2] instead of payload

### DIFF
--- a/templates/hooks/lib.ts
+++ b/templates/hooks/lib.ts
@@ -101,11 +101,17 @@ export function log(...args: any[]): void {
 
 // Main hook runner
 export function runHook(handlers: HookHandlers): void {
+  const hook_type = process.argv[2]
+  
   process.stdin.on('data', async (data) => {
     try {
-      const payload: HookPayload = JSON.parse(data.toString())
+      const inputData = JSON.parse(data.toString())
+      const payload: HookPayload = {
+        ...inputData,
+        hook_type: hook_type as any
+      }
 
-      switch (payload.hook_type) {
+      switch (hook_type) {
         case 'PreToolUse':
           if (handlers.preToolUse) {
             const response = await handlers.preToolUse(payload)


### PR DESCRIPTION
## Summary
- Modified `runHook` function to get `hook_type` from `process.argv[2]`
- The hook_type is now added to the payload object
- This allows Claude to pass the hook type via CLI arguments rather than requiring it in the JSON payload

## Test plan
✅ Tested PreToolUse hook with safe commands
✅ Tested PreToolUse hook blocks dangerous commands (rm -rf)
✅ Tested Notification hook
✅ Verified session files are created with correct hook_type
✅ All hooks work without hook_type in the input JSON

🤖 Generated with [Claude Code](https://claude.ai/code)