### PR TITLE
fix: add missing trailing comma in lib.ts

### DIFF
--- a/templates/hooks/lib.ts
+++ b/templates/hooks/lib.ts
@@ -102,13 +102,13 @@ export function log(...args: any[]): void {
 // Main hook runner
 export function runHook(handlers: HookHandlers): void {
   const hook_type = process.argv[2]
-  
+
   process.stdin.on('data', async (data) => {
     try {
       const inputData = JSON.parse(data.toString())
       const payload: HookPayload = {
         ...inputData,
-        hook_type: hook_type as any
+        hook_type: hook_type as any,
       }
 
       switch (hook_type) {


### PR DESCRIPTION
## Summary
- Fixed linting error by adding trailing comma after hook_type property in templates/hooks/lib.ts

## Test plan
- [x] Run `npm run lint` - passes with no errors

🤖 Generated with [Claude Code](https://claude.ai/code)