### PR TITLE
fix: add dangerous command protection to hooks template

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -80,7 +80,7 @@ This command sets up basic Claude Code hooks in your project:
       // Success message
       console.log(chalk.green('\n✨ Claude Code hooks initialized!\n'))
       console.log(chalk.gray('Next steps:'))
-      console.log(chalk.gray('1. Ensure Bun is installed (see warning above if not)'))
+      console.log(chalk.gray('1. Ensure Bun is installed (Bun is required to run Claude hooks)'))
       console.log(chalk.gray('2. Edit .claude/hooks/index.ts to customize hook behavior'))
       console.log(chalk.gray('3. Test your hooks by using Claude Code\n'))
     } catch (error) {

--- a/templates/hooks/index.ts
+++ b/templates/hooks/index.ts
@@ -25,7 +25,14 @@ async function preToolUse(payload: PreToolUsePayload): Promise<HookResponse> {
   // Example: Track bash commands
   if (payload.tool_name === 'Bash' && payload.tool_input && 'command' in payload.tool_input) {
     const bashInput = payload.tool_input as BashToolInput
-    console.log(`🚀 Running command: ${bashInput.command}`)
+    const command = bashInput.command
+    console.log(`🚀 Running command: ${command}`)
+    
+    // Block dangerous commands
+    if (command.includes('rm -rf /') || command.includes('rm -rf ~')) {
+      console.error('❌ Dangerous command detected! Blocking execution.')
+      return { action: 'reject', message: 'Dangerous command detected' }
+    }
   }
 
   // Add your custom logic here!


### PR DESCRIPTION
## Summary
- Added protection against `rm -rf /` and `rm -rf ~` commands in the PreToolUse handler
- Updated Bun installation message to be clearer about requirement
- Fixes CI test failures expecting dangerous command handling

## Test plan
- [x] All tests passing locally
- [x] CI tests should now pass

🤖 Generated with [Claude Code](https://claude.ai/code)