### PR TITLE
fix: add Windows compatibility for Bun detection

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -43,8 +43,11 @@ This command sets up basic Claude Code hooks in your project:
 
     // Check if Bun is installed
     const {spawn} = await import('node:child_process')
+    const isWindows = process.platform === 'win32'
+    const command = isWindows ? 'where' : 'which'
+    
     const checkBun = await new Promise<boolean>((resolve) => {
-      const child = spawn('which', ['bun'], {shell: false})
+      const child = spawn(command, ['bun'], {shell: false})
       child.on('error', () => resolve(false))
       child.on('exit', (code) => resolve(code === 0))
     })


### PR DESCRIPTION
## Summary
- Replace Unix-only 'which' command with platform-specific command detection
- Use 'where' on Windows and 'which' on Unix-like systems
- Ensures the CLI works correctly on Windows when checking if Bun is installed

## Test plan
- [x] Code compiles without errors
- [ ] Test on Windows machine to verify 'where' command works
- [ ] Test on Unix/macOS to ensure 'which' still works
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)