### PR TITLE
fix: resolve linting errors and ensure workflows wait for tests

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -9,7 +9,11 @@ permissions:
   contents: write
 
 jobs:
+  test-and-lint:
+    uses: ./.github/workflows/test.yml
+    
   release:
+    needs: test-and-lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,11 @@ on:
       - main
 
 jobs:
+  test-and-lint:
+    uses: ./.github/workflows/test.yml
+    
   release:
+    needs: test-and-lint
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-hooks",
-  "version": "1.1.3",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-hooks",
-      "version": "1.1.3",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -45,7 +45,6 @@ This command sets up basic Claude Code hooks in your project:
     const {spawn} = await import('node:child_process')
     const isWindows = process.platform === 'win32'
     const command = isWindows ? 'where' : 'which'
-    
     const checkBun = await new Promise<boolean>((resolve) => {
       const child = spawn(command, ['bun'], {shell: false})
       child.on('error', () => resolve(false))

--- a/templates/hooks/index.ts
+++ b/templates/hooks/index.ts
@@ -27,11 +27,11 @@ async function preToolUse(payload: PreToolUsePayload): Promise<HookResponse> {
     const bashInput = payload.tool_input as BashToolInput
     const command = bashInput.command
     console.log(`🚀 Running command: ${command}`)
-    
+
     // Block dangerous commands
     if (command.includes('rm -rf /') || command.includes('rm -rf ~')) {
       console.error('❌ Dangerous command detected! Blocking execution.')
-      return { action: 'reject', message: 'Dangerous command detected' }
+      return {action: 'reject', message: 'Dangerous command detected'}
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix biome formatting issues in src/commands/init.ts and templates/hooks/index.ts
- Update release.yml and onPushToMain.yml to depend on test-and-lint job
- Ensures releases only happen after all tests and linting pass

## Test plan
- [x] Run `npm run lint` locally - passes
- [ ] GitHub Actions workflows should run tests/lints before release
- [ ] All checks should pass on this PR

🤖 Generated with [Claude Code](https://claude.ai/code)