### PR TITLE
fix: make test workflow reusable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Add `workflow_call` trigger to test.yml to allow it to be called from other workflows
- Fixes release workflows that were failing because test.yml wasn't reusable

## Test plan
- [ ] GitHub Actions should run successfully on this PR
- [ ] Release workflows should now properly wait for tests to complete

🤖 Generated with [Claude Code](https://claude.ai/code)