### PR TITLE
docs: add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Version](https://img.shields.io/npm/v/claude-hooks.svg)](https://npmjs.org/package/claude-hooks)
 [![License](https://img.shields.io/npm/l/claude-hooks.svg)](https://github.com/johnlindquist/claude-hooks/blob/main/LICENSE)
+[![CI](https://github.com/johnlindquist/claude-hooks/actions/workflows/test.yml/badge.svg)](https://github.com/johnlindquist/claude-hooks/actions/workflows/test.yml)
 
 > TypeScript-powered hook system for Claude Code - write hooks with full type safety and auto-completion
 


### PR DESCRIPTION
## Summary
- Added CI status badge to README to show build status

## Test plan
- [x] Verified badge displays correctly
- [x] Link points to correct workflow

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a CI status badge to the README to display the current build status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->