### PR TITLE
fix: remove git plugin from semantic-release to resolve branch protection conflicts

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -22,13 +22,6 @@
       }
     ],
     "@semantic-release/npm",
-    "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary
- Removed @semantic-release/git plugin from semantic-release configuration
- This resolves conflicts with branch protection rules that were preventing releases

## Context
The semantic-release git plugin was trying to push version bumps directly to main, which was blocked by branch protection rules. This has been preventing releases from completing successfully.

By removing this plugin:
- GitHub releases will still be created
- npm packages will still be published
- Version tags will still be created
- But no commits will be pushed back to main

This allows all the pending fixes from recent commits to finally be released.

## Test plan
- [x] Verified semantic-release configuration is valid
- [x] PR will trigger release workflow after merge
- [x] Release should complete successfully without git push errors

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to simplify plugin usage during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->