### PR TITLE
fix: suppress misleading oclif TypeScript warning

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// Suppress oclif TypeScript warning for production usage
+process.env.OCLIF_TS_NODE = '0'
+
 import {execute} from '@oclif/core'
 
 // If no arguments provided, default to 'init' command


### PR DESCRIPTION
## Summary
- Suppress the misleading "Could not find typescript" warning that appears when running the CLI via npx
- Add `OCLIF_TS_NODE=0` environment variable to prevent oclif from looking for TypeScript in production

## Problem
When users run `npx claude-hooks`, they see:
```
Warning: Could not find typescript. Please ensure that typescript is a devDependency. Falling back to compiled source.
```

This warning is confusing because:
1. The distributed package is compiled JavaScript, not TypeScript
2. End users don't need TypeScript installed
3. The warning suggests something is wrong when everything is working correctly

## Solution
Set `process.env.OCLIF_TS_NODE = '0'` in the bin script to tell oclif not to look for TypeScript.

## Test Plan
- [x] Run `npx claude-hooks help` - no TypeScript warning should appear
- [x] All existing tests pass
- [x] CLI functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Suppressed a TypeScript-related warning during production usage to improve script output clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->