### PR TITLE
fix: properly resolve oclif TypeScript warning by setting execution directory

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 
-// Suppress oclif TypeScript warning for production usage
-process.env.OCLIF_TS_NODE = '0'
-
 import {execute} from '@oclif/core'
+import {dirname} from 'node:path'
+import {fileURLToPath} from 'node:url'
 
 // If no arguments provided, default to 'init' command
 const args = process.argv.slice(2)
@@ -11,4 +10,12 @@ if (args.length === 0) {
   process.argv.push('init')
 }
 
-await execute({dir: import.meta.url})
+// Get the actual directory of this script
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// Execute from the package root, not the current working directory
+await execute({
+  dir: dirname(__dirname),
+  // Explicitly set production mode to avoid TypeScript checks
+  development: false,
+})


### PR DESCRIPTION
## Summary
- Fix the "Could not find typescript" warning that appears when running the CLI via npx
- Set explicit package root directory instead of letting oclif search from current working directory
- Force development mode to false to prevent TypeScript detection in production

## Problem
When users run `npx claude-hooks@latest`, they see:
```
Warning: Could not find typescript. Please ensure that typescript is a devDependency. Falling back to compiled source.
```

This happens because:
1. Oclif searches for tsconfig.json starting from the current working directory
2. If the user's project has a tsconfig.json, oclif finds it and tries to load TypeScript
3. The warning appears even though the CLI is already compiled to JavaScript

## Solution
- Convert `import.meta.url` to an actual directory path
- Set the `dir` option to the package root (not the current working directory)
- Set `development: false` to force production mode
- This prevents oclif from searching parent directories for TypeScript configuration

## Test Plan
- [x] Run `node bin/run.js help` - no TypeScript warning appears
- [x] Create a directory with tsconfig.json and run the CLI - no warning appears
- [x] All existing tests pass
- [x] CLI functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)