### PR TITLE
feat: add --session-dir flag to print temp session directory path

### DIFF
--- a/templates/hooks/index.ts
+++ b/templates/hooks/index.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
 
+import {tmpdir} from 'node:os'
+import * as path from 'node:path'
 import type {
   NotificationPayload,
   PostToolUsePayload,
@@ -12,9 +14,16 @@ import type {
   UserPromptSubmitPayload,
   UserPromptSubmitResponse,
 } from './lib'
-
 import {runHook} from './lib'
 import {saveSessionData} from './session'
+
+// Check for --session-dir flag
+const args = process.argv.slice(2)
+if (args.includes('--session-dir')) {
+  const SESSIONS_DIR = path.join(tmpdir(), 'claude-hooks-sessions')
+  console.log(SESSIONS_DIR)
+  process.exit(0)
+}
 
 // PreToolUse handler - called before Claude uses any tool
 async function preToolUse(payload: PreToolUsePayload): Promise<PreToolUseResponse> {


### PR DESCRIPTION
Users can now run 'bun run .claude/hooks/index.ts --session-dir' to get the path where session data is stored (/tmp/claude-hooks-sessions)

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues

Closes #(issue number)

## Testing

- [ ] All tests pass locally
- [ ] Added new tests for changes
- [ ] Test coverage maintained or improved
- [ ] Manual testing completed

### Test Results
```
npm test
# Paste test output here
```

### Coverage Report
```
npm run test:coverage
# Paste coverage summary here
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information that reviewers should know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line option to display the location of the session directory. Use the `--session-dir` flag to print the path and exit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->